### PR TITLE
CSD-228 Added config page for image upload to use for opportunity headers

### DIFF
--- a/config/sync/config_pages.type.su_opportunities.yml
+++ b/config/sync/config_pages.type.su_opportunities.yml
@@ -1,0 +1,16 @@
+uuid: a62dc5f4-5b03-4efe-a8c3-346d78eaddee
+langcode: en
+status: true
+dependencies: {  }
+id: su_opportunities
+label: Opportunities
+context:
+  show_warning: true
+  group:
+    language: false
+  fallback:
+    language: ''
+menu:
+  path: /admin/appearance/opportunities
+  weight: 0
+  description: ''

--- a/config/sync/core.entity_form_display.config_pages.su_opportunities.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.su_opportunities.default.yml
@@ -1,0 +1,28 @@
+uuid: 8f808a2e-7eab-4e75-94c6-cc11c4edcc7e
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.su_opportunities
+    - field.field.config_pages.su_opportunities.su_opp_header_image
+    - image.style.thumbnail
+  module:
+    - focal_point
+id: config_pages.su_opportunities.default
+targetEntityType: config_pages
+bundle: su_opportunities
+mode: default
+content:
+  su_opp_header_image:
+    weight: 0
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+      preview_link: true
+      preview_link_modal: true
+      offsets: '50,50'
+    third_party_settings: {  }
+    type: image_focal_point
+    region: content
+hidden:
+  label: true

--- a/config/sync/core.entity_view_display.config_pages.su_opportunities.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.su_opportunities.default.yml
@@ -1,0 +1,28 @@
+uuid: 5c129203-aa6b-4102-81ad-b7f57fb019b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.su_opportunities
+    - field.field.config_pages.su_opportunities.su_opp_header_image
+    - responsive_image.styles.stanford_hero_block_wide
+  module:
+    - field_formatter_class
+    - responsive_image
+id: config_pages.su_opportunities.default
+targetEntityType: config_pages
+bundle: su_opportunities
+mode: default
+content:
+  su_opp_header_image:
+    weight: 0
+    label: hidden
+    settings:
+      responsive_image_style: stanford_hero_block_wide
+      image_link: ''
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+    type: responsive_image
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.node.su_opportunity.default.yml
+++ b/config/sync/core.entity_view_display.node.su_opportunity.default.yml
@@ -21,6 +21,7 @@ dependencies:
     - node.type.su_opportunity
     - views.view.su_spotlights
   module:
+    - config_pages
     - jumpstart_ui
     - layout_builder
     - layout_builder_restrictions
@@ -58,7 +59,7 @@ third_party_settings:
                 entity: layout_builder.entity
                 view_mode: view_mode
             additional: {  }
-            weight: 1
+            weight: 2
           98885d7b-0d6b-4b0b-acb2-03ee07f54423:
             uuid: 98885d7b-0d6b-4b0b-acb2-03ee07f54423
             region: main
@@ -80,6 +81,19 @@ third_party_settings:
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
+            additional: {  }
+            weight: 1
+          052c0f91-059f-4f9a-8d0f-d128b600429b:
+            uuid: 052c0f91-059f-4f9a-8d0f-d128b600429b
+            region: main
+            configuration:
+              id: config_pages_block
+              label: 'ConfigPages Block'
+              provider: config_pages
+              label_display: '0'
+              config_page_type: su_opportunities
+              config_page_view_mode: full
+              context_mapping: {  }
             additional: {  }
             weight: 0
         third_party_settings: {  }

--- a/config/sync/field.field.config_pages.su_opportunities.su_opp_header_image.yml
+++ b/config/sync/field.field.config_pages.su_opportunities.su_opp_header_image.yml
@@ -1,0 +1,38 @@
+uuid: 2f36c392-e733-422b-90be-7cc2a0a16a1b
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.su_opportunities
+    - field.storage.config_pages.su_opp_header_image
+  module:
+    - image
+id: config_pages.su_opportunities.su_opp_header_image
+field_name: su_opp_header_image
+entity_type: config_pages
+bundle: su_opportunities
+label: 'Header Background Image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: media/image/opportunities
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: 1000x400
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/sync/field.storage.config_pages.su_opp_header_image.yml
+++ b/config/sync/field.storage.config_pages.su_opp_header_image.yml
@@ -1,0 +1,30 @@
+uuid: 23204665-99d9-4c29-a012-f3979f5589ec
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+    - file
+    - image
+id: config_pages.su_opp_header_image
+field_name: su_opp_header_image
+entity_type: config_pages
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/migrate_plus.migration.solo_opportunities.yml
+++ b/config/sync/migrate_plus.migration.solo_opportunities.yml
@@ -21,7 +21,7 @@ source:
     type: su_opportunity
     basic_html: stanford_html
     image_destination: 'public://media/image/solo/'
-    apply_link_title: 'Apply'
+    apply_link_title: Apply
     learn_more_link_title: 'Learn More'
   item_selector: /OPPORTUNITIES/OPPORTUNITY
   fields:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added config pages to allow a custom image for the header on all opportunities content

# Need Review By (Date)
- 4/28

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. `drush @cardinalservice.local cim -y`
1. navigate to `/admin/appearance/opportunities`
1. upload an image and save
1. create an opportunity piece of content if none exit or view an existing one
1. verify the image you added earlier is displayed in the header above the node title.
1. styling yet to come.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
