### PR TITLE
CSD-130 Prevent duplicate from migration using a process plugin

### DIFF
--- a/config/sync/migrate_plus.migration.cardcourses_educ.yml
+++ b/config/sync/migrate_plus.migration.cardcourses_educ.yml
@@ -23,5 +23,9 @@ process:
       bundle: su_opportunity_service_theme
       entity_type: taxonomy_term
       ignore_case: true
+  skip:
+    plugin: skip_on_exist
+    migrate_exclude:
+      - cardcourses_educ
 destination: null
 migration_dependencies: {  }

--- a/config/sync/migrate_plus.migration.cardcourses_eng.yml
+++ b/config/sync/migrate_plus.migration.cardcourses_eng.yml
@@ -23,5 +23,9 @@ process:
       bundle: su_opportunity_service_theme
       entity_type: taxonomy_term
       ignore_case: true
+  skip:
+    plugin: skip_on_exist
+    migrate_exclude:
+      - cardcourses_eng
 destination: null
 migration_dependencies: {  }

--- a/config/sync/migrate_plus.migration.cardcourses_env.yml
+++ b/config/sync/migrate_plus.migration.cardcourses_env.yml
@@ -23,5 +23,9 @@ process:
       bundle: su_opportunity_service_theme
       entity_type: taxonomy_term
       ignore_case: true
+  skip:
+    plugin: skip_on_exist
+    migrate_exclude:
+      - cardcourses_env
 destination: null
 migration_dependencies: {  }

--- a/config/sync/migrate_plus.migration.cardcourses_general.yml
+++ b/config/sync/migrate_plus.migration.cardcourses_general.yml
@@ -11,6 +11,10 @@ migration_group: courses
 label: 'Education Courses'
 source:
   urls: 'https://explorecourses.stanford.edu/search?q=CARDCOURSES%3a%3ageneral&view=xml-20140630&filter-term-Winter=on&academicYear=&filter-term-Summer=on&filter-term-Autumn=on&filter-term-Spring=on&page=0&filter-coursestatus-Active=on&collapse='
-process: {  }
+process:
+  skip:
+    plugin: skip_on_exist
+    migrate_exclude:
+      - cardcourses_general
 destination: null
 migration_dependencies: {  }

--- a/config/sync/migrate_plus.migration.cardcourses_health.yml
+++ b/config/sync/migrate_plus.migration.cardcourses_health.yml
@@ -23,5 +23,9 @@ process:
       bundle: su_opportunity_service_theme
       entity_type: taxonomy_term
       ignore_case: true
+  skip:
+    plugin: skip_on_exist
+    migrate_exclude:
+      - cardcourses_health
 destination: null
 migration_dependencies: {  }

--- a/config/sync/migrate_plus.migration.cardcourses_humanrights.yml
+++ b/config/sync/migrate_plus.migration.cardcourses_humanrights.yml
@@ -23,5 +23,9 @@ process:
       bundle: su_opportunity_service_theme
       entity_type: taxonomy_term
       ignore_case: true
+  skip:
+    plugin: skip_on_exist
+    migrate_exclude:
+      - cardcourses_humanrights
 destination: null
 migration_dependencies: {  }

--- a/config/sync/migrate_plus.migration.cardcourses_identity.yml
+++ b/config/sync/migrate_plus.migration.cardcourses_identity.yml
@@ -23,5 +23,9 @@ process:
       bundle: su_opportunity_service_theme
       entity_type: taxonomy_term
       ignore_case: true
+  skip:
+    plugin: skip_on_exist
+    migrate_exclude:
+      - cardcourses_identity
 destination: null
 migration_dependencies: {  }

--- a/src/Plugin/migrate/process/SkipOnExist.php
+++ b/src/Plugin/migrate/process/SkipOnExist.php
@@ -12,7 +12,7 @@ use Drupal\migrate\Row;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class SkipOnExist.
+ * Migrate process plugin to query the other migrations for identical keys.
  *
  * @MigrateProcessPlugin(
  *   id = "skip_on_exist"
@@ -67,7 +67,6 @@ class SkipOnExist extends ProcessPluginBase implements ContainerFactoryPluginInt
    * {@inheritDoc}
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
-    static $here = FALSE;
     $source_ids = $row->getSourceIdValues();
     $migration_names = $this->getMigrationConfigs($source_ids);
 
@@ -83,13 +82,23 @@ class SkipOnExist extends ProcessPluginBase implements ContainerFactoryPluginInt
       }
 
       $count = $query->countQuery()->execute()->fetchField();
+
       if ((int) $count > 0) {
         throw new MigrateSkipRowException();
       }
     }
   }
 
-  protected function getMigrationConfigs($source_ids) {
+  /**
+   * List the migrations that have tables and same number of columns.
+   *
+   * @param array $source_ids
+   *   Keyed array of source ids from the current migration.
+   *
+   * @return string[]
+   *   List of migration names.
+   */
+  protected function getMigrationConfigs(array $source_ids) {
     if (!empty($this->migrations)) {
       return $this->migrations;
     }
@@ -111,9 +120,7 @@ class SkipOnExist extends ProcessPluginBase implements ContainerFactoryPluginInt
       $this->migrations[] = $name;
     }
 
-
     return $this->migrations;
-
   }
 
 }

--- a/src/Plugin/migrate/process/SkipOnExist.php
+++ b/src/Plugin/migrate/process/SkipOnExist.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\cardinal_service_profile\Plugin\migrate\process;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\MigrateSkipRowException;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class SkipOnExist.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "skip_on_exist"
+ * )
+ */
+class SkipOnExist extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Config Factory Service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Database connection service.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * List of migration ids excluding those defined by the exclude config.
+   *
+   * @var string[]
+   */
+  protected $migrations = [];
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory'),
+      $container->get('database')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory, Connection $database) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $config_factory;
+    $this->database = $database;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    static $here = FALSE;
+    $source_ids = $row->getSourceIdValues();
+    $migration_names = $this->getMigrationConfigs($source_ids);
+
+    foreach ($migration_names as $name) {
+      $query = $this->database->select("migrate_map_$name", 'm')
+        ->fields('m')
+        ->condition('destid1', 0, '>');
+
+      $i = 1;
+      foreach ($source_ids as $key_value) {
+        $query->condition("sourceid$i", $key_value);
+        $i++;
+      }
+
+      $count = $query->countQuery()->execute()->fetchField();
+      if ((int) $count > 0) {
+        throw new MigrateSkipRowException();
+      }
+    }
+  }
+
+  protected function getMigrationConfigs($source_ids) {
+    if (!empty($this->migrations)) {
+      return $this->migrations;
+    }
+    $prefix = 'migrate_plus.migration.';
+    $config_names = $this->configFactory->listAll($prefix);
+    $schema = $this->database->schema();
+
+    foreach ($config_names as $name) {
+      $name = str_replace($prefix, '', $name);
+
+      if (
+        (isset($this->configuration['migrate_exclude']) && in_array($name, $this->configuration['migrate_exclude'])) ||
+        !$schema->tableExists("migrate_map_$name") ||
+        !$schema->fieldExists("migrate_map_$name", 'sourceid' . count($source_ids))
+      ) {
+        continue;
+      }
+
+      $this->migrations[] = $name;
+    }
+
+
+    return $this->migrations;
+
+  }
+
+}

--- a/tests/src/Unit/Plugin/migrate/process/SkipOnExistTest.php
+++ b/tests/src/Unit/Plugin/migrate/process/SkipOnExistTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\Tests\cardinal_service_profile\Unit\Plugin\migrate\process;
+
+use Drupal\cardinal_service_profile\Plugin\migrate\process\SkipOnExist;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Query\Select;
+use Drupal\Core\Database\Schema;
+use Drupal\Core\Database\StatementInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\MigrateSkipRowException;
+use Drupal\migrate\Row;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class SkipOnExistTest.
+ *
+ * @group cardinal_service_profile
+ * @coversDefaultClass \Drupal\cardinal_service_profile\Plugin\migrate\process\SkipOnExist
+ */
+class SkipOnExistTest extends UnitTestCase {
+
+  /**
+   * @var \Drupal\cardinal_service_profile\Plugin\migrate\process\SkipOnExist
+   */
+  protected $processPlugin;
+
+  /**
+   * If the schema method should return the table exists.
+   *
+   * @var bool
+   */
+  protected $migrateTableExists = FALSE;
+
+  /**
+   * Number of rows in the database that match the source ids.
+   *
+   * @var int
+   */
+  protected $migrateTableCount = 0;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $config_factory->method('listAll')->willReturn(['foo', 'bar', 'baz']);
+
+    $schema = $this->createMock(Schema::class);
+    $schema->method('tableExists')
+      ->willReturnReference($this->migrateTableExists);
+    $schema->method('fieldExists')
+      ->willReturnReference($this->migrateTableExists);
+
+    $statement = $this->createMock(StatementInterface::class);
+    $statement->method('fetchField')
+      ->willReturnReference($this->migrateTableCount);
+
+    $select = $this->createMock(Select::class);
+    $select->method('fields')->willReturnSelf();
+    $select->method('condition')->willReturnSelf();
+    $select->method('countQuery')->willReturnSelf();
+    $select->method('execute')->willReturn($statement);
+
+    $database = $this->createMock(Connection::class);
+    $database->method('schema')->willReturn($schema);
+    $database->method('select')->willReturn($select);
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $config_factory);
+    $container->set('database', $database);
+
+    $config = [];
+    $this->processPlugin = SkipOnExist::create($container, $config, '', []);
+  }
+
+  /**
+   * Migration Tables haven't been created.
+   */
+  public function testTablesDontExist() {
+    $migration = $this->createMock(MigrateExecutableInterface::class);
+    $row = $this->createMock(Row::class);
+    $row->method('getSourceIdValues')
+      ->willReturn(['guid' => $this->randomMachineName()]);
+    $this->assertNull($this->processPlugin->transform('foo', $migration, $row, NULL));
+  }
+
+  /**
+   * When the migration tables exist, it will throw an exception.
+   */
+  public function testTablesExistSkip() {
+    $this->migrateTableExists = TRUE;
+    $migration = $this->createMock(MigrateExecutableInterface::class);
+    $row = $this->createMock(Row::class);
+    $row->method('getSourceIdValues')
+      ->willReturn(['guid' => $this->randomMachineName()]);
+    $this->assertNull($this->processPlugin->transform('foo', $migration, $row, NULL));
+
+    $this->migrateTableCount = 1;
+    $this->expectException(MigrateSkipRowException::class);
+    $this->processPlugin->transform('foo', $migration, $row, NULL);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Created a migrate process plugin that queries other migration tables for the item already imported.

# Need Review By (Date)
- 6/16

# Urgency
- high

# Steps to Test
1. `composer require su-hkku/cardinal_service_profile:dev-CSD-130`
1. `blt drupal:sync --site=cardinalservice`
1. run a couple migration importers: `drush @cardinalservice.local mim cardcourses_educ` and `drush @cardinalservice.local mim cardcourses_eng`
1. see how the second import produced a couple ignored items. :+1: 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
