### PR TITLE
Added a help section with contents of the help documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Stanford Profile](https://github.com/SU-SWS/stanford_profile)
+# [Cardinal Service Profile](hhttps://github.com/SU-HKKU/cardinal_service_profile)
 ##### 8.x
 [![CircleCI](https://circleci.com/gh/SU-HKKU/cardinal_service_profile.svg?style=shield)](https://circleci.com/gh/SU-HKKU/cardinal_service_profile)
 
@@ -14,7 +14,13 @@ Changelog: [Changelog.md](CHANGELOG.md)
 Description
 ---
 
-This is the main installation profile for Stanford Web Services' self service platform and is used as a base for more.
+This is the installation profile for Cardinal Service. It is based on and requires the [Stanford Profile](https://github.com/SU-SWS/stanford_profile).
+A nightly task will pull updates from  stanford profile and produce a pull request in github for testing and review.
+
+Profile specific documentation is available in the [help](help) directory. The help documentation in that directory
+is available in the UI at `/admin/help/cardinal-service`. When creating new help documenation, ensure there is an `h1`
+within the file. An `h1` is denoted by a single `#` at the beginning of the file. Each help file produces its own path
+available to the site managers.
 
 Accessibility
 ---

--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "drupal/views_bulk_edit": "^2.4",
         "drupal/views_field_view": "^1.0@beta",
         "drupal/views_taxonomy_term_name_depth": "^7.0",
+        "michelf/php-markdown": "^1.9",
         "su-sws/stanford_profile": "dev-8.x-1.x"
     },
     "autoload": {

--- a/help/opportunities.md
+++ b/help/opportunities.md
@@ -1,0 +1,2 @@
+# Opportunities
+

--- a/help/spotlight.md
+++ b/help/spotlight.md
@@ -1,0 +1,1 @@
+# Spotlight Stories

--- a/modules/cardinal_service_profile_helper/cardinal_service_profile_helper.routing.yml
+++ b/modules/cardinal_service_profile_helper/cardinal_service_profile_helper.routing.yml
@@ -17,3 +17,11 @@ cardinal_service.csv_template:
     parameters:
       migration:
         type: entity:migration
+
+cardinal_service.help_document:
+  path: '/admin/help/cardinal-service/{document}'
+  defaults:
+    _controller: '\Drupal\cardinal_service_profile_helper\Controller\Documentation::getDocumentation'
+    _title_callback: '\Drupal\cardinal_service_profile_helper\Controller\Documentation::getTitle'
+  requirements:
+    _permission: 'access administration pages'

--- a/modules/cardinal_service_profile_helper/src/Controller/Documentation.php
+++ b/modules/cardinal_service_profile_helper/src/Controller/Documentation.php
@@ -6,12 +6,21 @@ use Drupal\Core\Controller\ControllerBase;
 use Michelf\MarkdownExtra;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * Class Documentation.
+ *
+ * @package Drupal\cardinal_service_profile_helper\Controller
+ */
 class Documentation extends ControllerBase {
 
   /**
-   * @param null $document
+   * Controller callback to get the help document contents.
+   *
+   * @param string $document
+   *   Help file name.
    *
    * @return array
+   *   Help markdown markup converted to html.
    */
   public function getDocumentation($document) {
     // Invalid path.
@@ -52,4 +61,3 @@ class Documentation extends ControllerBase {
   }
 
 }
-

--- a/modules/cardinal_service_profile_helper/src/Controller/Documentation.php
+++ b/modules/cardinal_service_profile_helper/src/Controller/Documentation.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\cardinal_service_profile_helper\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Michelf\MarkdownExtra;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class Documentation extends ControllerBase {
+
+  /**
+   * @param null $document
+   *
+   * @return array
+   */
+  public function getDocumentation($document) {
+    // Invalid path.
+    if (!file_exists(self::getProfilePath() . "/help/$document.md")) {
+      throw new NotFoundHttpException($this->t('Document @document not found', ['@document' => $document]));
+    }
+    $html = MarkdownExtra::defaultTransform(file_get_contents($this->getProfilePath() . "/help/$document.md"));
+    $h1 = preg_grep('/<h1>.*?<\/h1>/', explode("\n", $html));
+
+    return [
+      '#markup' => preg_replace('/<h1>.*?<\/h1>/', '', $html),
+      '#title' => !empty($h1[0]) ? strip_tags($h1[0]) : NULL,
+    ];
+  }
+
+  /**
+   * Page title callback.
+   *
+   * @param string $document
+   *   File name of the help document.
+   *
+   * @return string
+   *   Page title.
+   */
+  public function getTitle($document) {
+    $html = $this->getDocumentation($document);
+    return $html['#title'];
+  }
+
+  /**
+   * Get the path to the CS profile.
+   *
+   * @return string
+   *   Path to the CS profile
+   */
+  protected static function getProfilePath() {
+    return drupal_get_path('profile', 'cardinal_service_profile');
+  }
+
+}
+

--- a/modules/cardinal_service_profile_helper/tests/src/Kernel/Controller/DocumentationTest.php
+++ b/modules/cardinal_service_profile_helper/tests/src/Kernel/Controller/DocumentationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\Tests\cardinal_service_profile_helper\Kernel\Controller;
+
+use Drupal\cardinal_service_profile_helper\Controller\Documentation;
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Class DocumentationTest.
+ *
+ * @group cardinal_service_profile
+ * @coversDefaultClass \Drupal\cardinal_service_profile_helper\Controller\Documentation
+ */
+class DocumentationTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'cardinal_service_profile_helper',
+  ];
+
+  /**
+   * Controller object.
+   *
+   * @var \Drupal\cardinal_service_profile_helper\Controller\Documentation
+   */
+  protected $controller;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->controller = new Documentation();
+  }
+
+  /**
+   * Routes without a help document will return 404 response.
+   */
+  public function testPageNotFound() {
+    $this->expectException(NotFoundHttpException::class);
+    $this->controller->getDocumentation('foo-bar');
+  }
+
+  /**
+   * Help pages will consist of some markup and a title.
+   */
+  public function testDocumentationController() {
+    $this->assertCount(2, $this->controller->getDocumentation('opportunities'));
+    $this->assertNotEmpty($this->controller->getTitle('opportunities'));
+  }
+
+}

--- a/src/Plugin/HelpSection/CardinalServiceSection.php
+++ b/src/Plugin/HelpSection/CardinalServiceSection.php
@@ -23,7 +23,7 @@ class CardinalServiceSection extends HelpSectionPluginBase {
    */
   public function listTopics() {
     $links = [];
-    $profile_path = self::getProfilePath();
+    $profile_path = $this::getProfilePath();
 
     foreach (glob("$profile_path/help/*.md") as $help_file) {
       $help_html = MarkdownExtra::defaultTransform(file_get_contents($help_file));
@@ -37,6 +37,8 @@ class CardinalServiceSection extends HelpSectionPluginBase {
 
   /**
    * Get the path to the CS profile.
+   *
+   * @codeCoverageIgnore Unit tests wont work with the function call.
    *
    * @return string
    *   Path to the CS profile

--- a/src/Plugin/HelpSection/CardinalServiceSection.php
+++ b/src/Plugin/HelpSection/CardinalServiceSection.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\cardinal_service_profile\Plugin\HelpSection;
+
+use Drupal\Core\Link;
+use Drupal\help\Plugin\HelpSection\HelpSectionPluginBase;
+use Michelf\MarkdownExtra;
+
+/**
+ * Provides the module topics list section for the help page.
+ *
+ * @HelpSection(
+ *   id = "cardinal_service",
+ *   title = @Translation("Cardinal Service"),
+ *   description =  @Translation(""),
+ *   weight = -1000
+ * )
+ */
+class CardinalServiceSection extends HelpSectionPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function listTopics() {
+    $links = [];
+    $profile_path = self::getProfilePath();
+
+    foreach (glob("$profile_path/help/*.md") as $help_file) {
+      $help_html = MarkdownExtra::defaultTransform(file_get_contents($help_file));
+      $h1 = preg_grep('/<h1>.*?<\/h1>/', explode("\n", $help_html));
+      $document = substr(basename($help_file), 0, -3);
+      $links[] = Link::createFromRoute(strip_tags($h1[0]), 'cardinal_service.help_document', ['document' => $document])
+        ->toRenderable();
+    }
+    return $links;
+  }
+
+  /**
+   * Get the path to the CS profile.
+   *
+   * @return string
+   *   Path to the CS profile
+   */
+  protected static function getProfilePath() {
+    return drupal_get_path('profile', 'cardinal_service_profile');
+  }
+
+}

--- a/tests/src/Unit/Plugin/HelpSection/CardinalServiceSectionTest.php
+++ b/tests/src/Unit/Plugin/HelpSection/CardinalServiceSectionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\Tests\cardinal_service_profile\Unit\Plugin\HelpSection;
+
+use Drupal\cardinal_service_profile\Plugin\HelpSection\CardinalServiceSection;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class CardinalServiceSectionTest
+ *
+ * @group cardinal_service_profile
+ * @coversDefaultClass \Drupal\cardinal_service_profile\Plugin\HelpSection\CardinalServiceSection
+ */
+class CardinalServiceSectionTest extends UnitTestCase {
+
+  /**
+   * The help section should return some links.
+   */
+  public function testPlugin() {
+    $plugin = new TestCardinalServiceSection([], '', []);
+    $topics = $plugin->listTopics();
+    $this->assertNotEmpty($topics);
+  }
+
+}
+
+class TestCardinalServiceSection extends CardinalServiceSection {
+
+  protected static function getProfilePath() {
+    return dirname(__DIR__, 5);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a help section with links to view the markdown files in the `help` directory.

# Need Review By (Date)
- asap

# Urgency
- high

# Steps to Test
1. pull the latest from the stack branch & `composer install -n`
1. `composer require SU-HKKU/cardinal_service_profile:dev-help-ui`
1. `blt drupal:sync --site=cardinalservice`
1. login and view the page `/admin/help`
1. click on one of the links in the top "Cardinal Service" section
1. validate you see an empty page. (contents of the help documents coming soon)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
