### PR TITLE
CSD-380 Add resource field validation

### DIFF
--- a/cardinal_service_profile.inc
+++ b/cardinal_service_profile.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -311,6 +312,24 @@ function _cardinal_service_node_imported(NodeInterface $node) {
 
       if ($migrated > 0) {
         return $migration_name;
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_bundle_field_info_alter().
+ */
+function cardinal_service_profile_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle) {
+  if ($bundle === 'stanford_page') {
+    $resource_fields = [
+      'su_page_resource_type',
+      'su_page_resource_audience',
+      'su_page_resource_dimension',
+    ];
+    foreach ($resource_fields as $resource_field) {
+      if (isset($fields[$resource_field])) {
+        $fields[$resource_field]->addConstraint('ResourceFields', []);
       }
     }
   }

--- a/src/Plugin/Validation/Constraint/ResourceFields.php
+++ b/src/Plugin/Validation/Constraint/ResourceFields.php
@@ -5,7 +5,7 @@ namespace Drupal\cardinal_service_profile\Plugin\Validation\Constraint;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * Class ResourceFields
+ * Resource fields constraint.
  *
  * @Constraint(
  *   id = "ResourceFields",

--- a/src/Plugin/Validation/Constraint/ResourceFields.php
+++ b/src/Plugin/Validation/Constraint/ResourceFields.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\cardinal_service_profile\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class ResourceFields
+ *
+ * @Constraint(
+ *   id = "ResourceFields",
+ *   label = @Translation("Resource Fields", context = "Validation")
+ * )
+ */
+class ResourceFields extends Constraint {
+
+  /**
+   * All fields on the resources have to be populated if any of them are filled.
+   *
+   * @var string
+   */
+  public $fieldsNotPopulated = 'All resource fields are required.';
+
+}

--- a/src/Plugin/Validation/Constraint/ResourceFieldsValidator.php
+++ b/src/Plugin/Validation/Constraint/ResourceFieldsValidator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\cardinal_service_profile\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validator for resource field constraint.
+ *
+ * @package Drupal\cardinal_service_profile\Plugin\Validation\Constraint
+ */
+class ResourceFieldsValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function validate($value, Constraint $constraint) {
+    $resource_fields = [
+      'su_page_resource_type' => 0,
+      'su_page_resource_audience' => 0,
+      'su_page_resource_dimension' => 0,
+    ];
+
+    foreach (array_keys($resource_fields) as $resource_field) {
+      if ($value->getEntity()->hasField($resource_field)) {
+        $resource_fields[$resource_field] = $value->getEntity()
+          ->get($resource_field)
+          ->count();
+      }
+    }
+
+    if (array_filter($resource_fields) && count(array_filter($resource_fields)) != count($resource_fields)) {
+      $this->context->addViolation($constraint->fieldsNotPopulated);
+    }
+  }
+
+}

--- a/tests/src/Unit/Plugin/Validation/Constraint/ResourceFieldsValidatorTest.php
+++ b/tests/src/Unit/Plugin/Validation/Constraint/ResourceFieldsValidatorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\Tests\cardinal_service_profile\Unit\Plugin\Validation\Constraint;
+
+use Drupal\cardinal_service_profile\Plugin\Validation\Constraint\ResourceFields;
+use Drupal\cardinal_service_profile\Plugin\Validation\Constraint\ResourceFieldsValidator;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Class ResourceFieldsValidatorTest.
+ *
+ * @group cardinal_service_profile
+ * @coversDefaultClass \Drupal\cardinal_service_profile\Plugin\Validation\Constraint\ResourceFieldsValidator
+ */
+class ResourceFieldsValidatorTest extends UnitTestCase {
+
+  /**
+   * Has the field value already been returned via the mock field list.
+   *
+   * @var bool
+   */
+  protected $fieldValueReturned = FALSE;
+
+  /**
+   * All fields are populated.
+   */
+  public function testNoErrorValidation() {
+    $validator = new TestResourceFieldsValidator();
+    $validator->initialize($this->getContext());
+
+    $field_value = $this->createMock(FieldItemListInterface::class);
+    $field_value->method('count')->willReturn(1);
+
+    $entity = $this->createMock(FieldableEntityInterface::class);
+    $entity->method('hasField')->willReturn(TRUE);
+    $entity->method('get')->willReturn($field_value);
+
+    $field_value->method('getEntity')->willReturn($entity);
+
+    $constraint = new ResourceFields();
+    $validator->validate($field_value, $constraint);
+    $this->assertFalse($validator->hasErrors());
+  }
+
+  /**
+   * None of the field are populated.
+   */
+  public function testEmptyFieldsValidation() {
+    $validator = new TestResourceFieldsValidator();
+    $validator->initialize($this->getContext());
+
+    $field_value = $this->createMock(FieldItemListInterface::class);
+    $field_value->method('count')->willReturn(NULL);
+
+    $entity = $this->createMock(FieldableEntityInterface::class);
+    $entity->method('hasField')->willReturn(TRUE);
+    $entity->method('get')->willReturn($field_value);
+
+    $field_value->method('getEntity')->willReturn($entity);
+
+    $constraint = new ResourceFields();
+    $validator->validate($field_value, $constraint);
+    $this->assertFalse($validator->hasErrors());
+  }
+
+  /**
+   * At least 1 field is not populated while the others are.
+   */
+  public function testErrorValidation() {
+    $validator = new TestResourceFieldsValidator();
+    $validator->initialize($this->getContext());
+
+    $field_value = $this->createMock(FieldItemListInterface::class);
+    $field_value->method('count')
+      ->will($this->returnCallback([$this, 'getFieldCallback']));;
+
+    $entity = $this->createMock(FieldableEntityInterface::class);
+    $entity->method('hasField')->willReturn(TRUE);
+    $entity->method('get')->willReturn($field_value);
+
+    $field_value->method('getEntity')->willReturn($entity);
+
+    $constraint = new ResourceFields();
+    $validator->validate($field_value, $constraint);
+    $this->assertTrue($validator->hasErrors());
+  }
+
+  /**
+   * Field count callback from the mock object.
+   *
+   * @return int
+   *   Field list count.
+   */
+  public function getFieldCallback() {
+    $value = $this->fieldValueReturned ? 0 : 1;
+    $this->fieldValueReturned = TRUE;
+    return $value;
+  }
+
+  /**
+   * Build a context object for the validator.
+   *
+   * @return \Symfony\Component\Validator\Context\ExecutionContext
+   */
+  protected function getContext() {
+    $validator = $this->createMock(ValidatorInterface::class);
+    $translator = $this->createMock(TranslatorInterface::class);
+    return new ExecutionContext($validator, '', $translator);
+  }
+
+}
+
+class TestResourceFieldsValidator extends ResourceFieldsValidator {
+
+  /**
+   * If the violation has errors.
+   *
+   * @return bool
+   *   Violations exist.
+   */
+  public function hasErrors() {
+    return $this->context->getViolations()->count() > 0;
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added validation for basic page when a user enters resource fields, they have to enter all 3 resource fields.

# Need Review By (Date)
- 9/3

# Urgency
- low

# Steps to Test
1. checkout this branch
1. clear caches
1. attempt to create a basic page, leave all resource fields empty, validate no errors occur
1. attempt to create/edit a basic page, select an option from one of the resource fields, validate you get an error
1. attempt to create/edit a basic page, select an option from all 3 resource fields, validate no errors occur.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
