### PR TITLE
time migrate skip

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,9 @@
     },
     "extra": {
         "patches": {
+            "drupal/conditional_fields": {
+                "https://www.drupal.org/project/conditional_fields/issues/3192044": "https://www.drupal.org/files/issues/2021-01-14/fix-notice-3192044-14.patch"
+            },
             "drupal/core": {
                 "https://www.drupal.org/project/drupal/issues/3015152": "https://www.drupal.org/files/issues/2019-12-05/3015152-tps-26.patch",
                 "https://www.drupal.org/project/drupal/issues/2577923": "https://www.drupal.org/files/issues/2019-10-14/2577923-125.patch",

--- a/config/sync/migrate_plus.migration.solo_opportunities.yml
+++ b/config/sync/migrate_plus.migration.solo_opportunities.yml
@@ -356,6 +356,11 @@ process:
       plugin: skip_on_equal
       compare: '@su_opp_submissions_open'
       method: process
+    -
+      plugin: skip_on_time_compare
+      compare: '>'
+      value: 'now +2years'
+      method: process
   su_opp_deadline_time:
     -
       plugin: default_value

--- a/src/Plugin/migrate/process/SkipOnTime.php
+++ b/src/Plugin/migrate/process/SkipOnTime.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\cardinal_service_profile\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate_plus\Plugin\migrate\process\SkipOnValue;
+
+/**
+ * Skip the row or the process if the time is different.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "skip_on_time_compare"
+ * )
+ */
+class SkipOnTime extends SkipOnValue {
+
+  /**
+   * Transforms the value being compared from the previous process data.
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $original_value = strtotime($value);
+    $comparison_value = strtotime($this->configuration['value']);
+    switch ($this->configuration['compare']) {
+      case '>':
+        if ($original_value > $comparison_value) {
+          $this->configuration['value'] = $value;
+        }
+        break;
+      case '<':
+        if ($original_value < $comparison_value) {
+          $this->configuration['value'] = $value;
+        }
+        break;
+
+    }
+    return parent::transform($value, $migrate_executable, $row, $destination_property);
+  }
+
+}

--- a/tests/src/Unit/Plugin/migrate/process/SkipOnTimeTest.php
+++ b/tests/src/Unit/Plugin/migrate/process/SkipOnTimeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\Tests\cardinal_service_profile\Unit\Plugin\migrate\process;
+
+use Drupal\cardinal_service_profile\Plugin\migrate\process\SkipOnTime;
+use Drupal\migrate\MigrateExecutable;
+use Drupal\migrate\MigrateSkipProcessException;
+use Drupal\migrate\Row;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class SkipOnTimeTest.
+ *
+ * @coversDefaultClass \Drupal\cardinal_service_profile\Plugin\migrate\process\SkipOnTime
+ */
+class SkipOnTimeTest extends UnitTestCase {
+
+  /**
+   * Test the process plugin if the time is below the comparison value.
+   */
+  public function testProcessPlugin() {
+    $plugin = new SkipOnTime([
+      'compare' => '>',
+      'value' => 'now +1day',
+      'method' => 'process',
+    ], '', []);
+
+    $migration = $this->createMock(MigrateExecutable::class);
+    $row = $this->createMock(Row::class);
+
+    $time = time();
+    $this->assertEquals($time, $plugin->transform($time, $migration, $row, NULL));
+
+    $plugin = new SkipOnTime([
+      'compare' => '<',
+      'value' => 'now +1day',
+      'method' => 'process',
+    ], '', []);
+
+    $migration = $this->createMock(MigrateExecutable::class);
+    $row = $this->createMock(Row::class);
+
+    $this->expectException(MigrateSkipProcessException::class);
+    $plugin->transform($time, $migration, $row, NULL);
+
+  }
+
+  /**
+   * Test the process plugin if the time is above the comparison value.
+   */
+  public function testProcessPluginOver() {
+    $plugin = new SkipOnTime([
+      'compare' => '<',
+      'value' => 'now +1day',
+      'method' => 'process',
+    ], '', []);
+
+    $migration = $this->createMock(MigrateExecutable::class);
+    $row = $this->createMock(Row::class);
+
+    $time = time() + 60 * 60 * 24 * 30;
+    $this->assertEquals($time, $plugin->transform($time, $migration, $row, NULL));
+
+
+    $plugin = new SkipOnTime([
+      'compare' => '>',
+      'value' => 'now +1day',
+      'method' => 'process',
+    ], '', []);
+
+    $migration = $this->createMock(MigrateExecutable::class);
+    $row = $this->createMock(Row::class);
+
+    $this->expectException(MigrateSkipProcessException::class);
+    $plugin->transform($time, $migration, $row, NULL);
+
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- migrate process plugin that compares a timestamp to the current date and time
- Add the process plugin so that if a "deadline" occurs over 2 year in the future, the deadline field will be empty. This is used for "Rolling deadlines"

# Need Review By (Date)
- asap

# Urgency
- high

# Steps to Test
1. checkout this branch
2. sync the site `blt drupal:sync --site=cardinalservice`
3. run the importer `drush @cardinalservice.local mim solo_opportunities --update`
4. view the page `/opportunities/community-service-work-study-csws-academic-year-20-21` and validate the deadline is gone.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
