### PR TITLE
2022 04 22  compatibility updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ code_coverage: &code_coverage
     - run:
         name: Run PHP Unit Coverage Tests
         command: |
-          composer global require SU-SWS/stanford-caravan:dev-8.x-2.x#02be96bd3fdb08f960647b92e01cabc45de41282
+          composer global require SU-SWS/stanford-caravan:dev-8.x-2.x
           ~/.composer/vendor/bin/sws-caravan phpunit /var/www/html --extension-dir=/var/www/test --with-coverage
     - store_test_results:
         path: /var/www/html/artifacts/phpunit
@@ -48,7 +48,7 @@ d9_codeception: &d9_codeception
     - run:
         name: Run Codeception Tests
         command: |
-          composer global require SU-SWS/stanford-caravan:dev-8.x-2.x#02be96bd3fdb08f960647b92e01cabc45de41282
+          composer global require SU-SWS/stanford-caravan:dev-8.x-2.x
           ~/.composer/vendor/bin/sws-caravan codeception /var/www/html --extension-dir=/var/www/test
     - store_test_results:
         path: /var/www/html/artifacts

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -183,6 +183,7 @@ module:
   text: 0
   token: 0
   toolbar: 0
+  transliterate_filenames: 0
   ui_patterns: 0
   ui_patterns_ds: 0
   ui_patterns_layouts: 0


### PR DESCRIPTION
Tests weren't able to run due to compatibility issues that couldn't create a build artifact properly in CircleCI. This branch:
- Uses the most recent `stanford_caravan` version to run tests to work with the most recent versions of `domain_301_redirect` and `link_title_formatter` (sp?) module
- Enables the `transliterate_filenames` module (now a dependency for `stanford_` modules).

I referenced two commits from `caw_profile` for this:
- https://github.com/SU-SWS/caw_profile/commit/d5d66345d91ceec6b8a5b7f3f2839fcaccc8c93d
- https://github.com/SU-SWS/caw_profile/commit/0de13c06c3f5d593a450a02a51b5f0e4675ac5ac
