### PR TITLE
Locked migrate_plus version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
         "drupal/field_delimiter": "^1.1",
         "drupal/flag": "^4.0@beta",
         "drupal/hotjar": "^2.0",
+        "drupal/migrate_plus": "5.2",
         "drupal/node_title_help_text": "^1.2",
         "drupal/smart_trim": "^1.7",
         "drupal/views_field_view": "^1.0@beta",


### PR DESCRIPTION
https://www.drupal.org/project/migrate_plus dropped releases today, one of which is incompatible with a patch we have in `stanford_migrate`.

There is a 6.0.0 release and also a 8.x-5.3 release. The 5.3 release breaks the patch.

We need to get releases cut for `cardinal_service_profile`  and `ace-gryphon` so this PR manually locks `migrate_plus` to version 8.x-5.2 for now.